### PR TITLE
Import Paddock model in farms router

### DIFF
--- a/apps/backend/app/routers/farms.py
+++ b/apps/backend/app/routers/farms.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import AuthContext, get_current_auth
 from ..db import get_db_session
+from ..models import Paddock
 from ..schemas import PaddockCreate, PaddockResponse
 from ..services.ownership import ensure_farm
 from ..services.serializers import serialize_paddock


### PR DESCRIPTION
## Summary
- import the Paddock ORM model in the farms router so select(Paddock) resolves

## Testing
- PYTHONPATH=apps/backend python - <<'PY' ... (FastAPI TestClient request of GET /api/farms/{farm_id}/paddocks)


------
https://chatgpt.com/codex/tasks/task_e_68d32d8a55a88324b12b1d27fca32ccf