### PR TITLE
Add canonical REST endpoints for owners, farms, and paddocks

### DIFF
--- a/apps/backend/app/routers/farms.py
+++ b/apps/backend/app/routers/farms.py
@@ -3,17 +3,52 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import AuthContext, get_current_auth
 from ..db import get_db_session
-from ..schemas import PaddockCreate, PaddockResponse
+from ..models import Farm, Paddock
+from ..schemas import FarmCreatePayload, FarmPublic, PaddockCreate, PaddockResponse
 from ..services.ownership import ensure_farm
-from ..services.serializers import serialize_paddock
+from ..services.serializers import serialize_farm, serialize_paddock
 
 router = APIRouter(prefix="/api/farms", tags=["farms"])
+
+
+@router.get("", response_model=list[FarmPublic])
+async def list_farms(
+    owner_id: uuid.UUID | None = Query(default=None),
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[FarmPublic]:
+    target_owner_id = owner_id or auth.owner_id
+    if target_owner_id != auth.owner_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not allowed to view farms for another owner")
+    query = select(Farm).where(Farm.owner_id == target_owner_id).order_by(Farm.created_at.desc())
+    result = await session.execute(query)
+    farms = result.scalars().all()
+    return [serialize_farm(farm) for farm in farms]
+
+
+@router.post("", response_model=FarmPublic, status_code=status.HTTP_201_CREATED)
+async def create_farm(
+    payload: FarmCreatePayload,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_db_session),
+) -> FarmPublic:
+    owner_id = payload.ownerId or auth.owner_id
+    if owner_id != auth.owner_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cannot create farm for another owner")
+    name = payload.name.strip()
+    if not name:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="name is required")
+    farm = Farm(owner_id=owner_id, name=name, notes=payload.notes)
+    session.add(farm)
+    await session.commit()
+    await session.refresh(farm)
+    return serialize_farm(farm)
 
 
 @router.get("/{farm_id}/paddocks", response_model=list[PaddockResponse])
@@ -50,3 +85,5 @@ async def create_paddock(
     await session.commit()
     await session.refresh(paddock)
     return serialize_paddock(paddock)
+
+

--- a/apps/backend/app/routers/owners.py
+++ b/apps/backend/app/routers/owners.py
@@ -6,13 +6,50 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import AuthContext, get_current_auth
 from ..db import get_db_session
-from ..models import Farm
-from ..schemas import FarmCreate, FarmResponse
+from ..models import Farm, Owner, Profile
+from ..schemas import FarmCreate, FarmResponse, OwnerCreatePayload, OwnerPublic
+from ..services.serializers import serialize_owner
 
-router = APIRouter(prefix="/api/owners/me", tags=["owners"])
+router = APIRouter(prefix="/api/owners", tags=["owners"])
 
 
-@router.get("/farms", response_model=list[FarmResponse])
+@router.get("", response_model=list[OwnerPublic])
+async def list_owners(
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[OwnerPublic]:
+    query = select(Owner).where(Owner.id == auth.owner_id)
+    result = await session.execute(query)
+    owners = result.scalars().all()
+    return [serialize_owner(owner) for owner in owners]
+
+
+@router.post("", response_model=OwnerPublic, status_code=status.HTTP_201_CREATED)
+async def create_owner(
+    payload: OwnerCreatePayload,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_db_session),
+) -> OwnerPublic:
+    name = payload.name.strip()
+    if not name:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="name is required")
+
+    owner = Owner(name=name)
+    session.add(owner)
+    await session.flush()
+
+    profile = await session.get(Profile, auth.user_id)
+    if profile:
+        profile.owner_id = owner.id
+    else:
+        session.add(Profile(user_id=auth.user_id, owner_id=owner.id))
+
+    await session.commit()
+    await session.refresh(owner)
+    return serialize_owner(owner)
+
+
+@router.get("/me/farms", response_model=list[FarmResponse])
 async def list_farms(
     auth: AuthContext = Depends(get_current_auth),
     session: AsyncSession = Depends(get_db_session),
@@ -23,7 +60,7 @@ async def list_farms(
     return list(farms)
 
 
-@router.post("/farms", response_model=FarmResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/me/farms", response_model=FarmResponse, status_code=status.HTTP_201_CREATED)
 async def create_farm(
     auth: AuthContext = Depends(get_current_auth),
     session: AsyncSession = Depends(get_db_session),

--- a/apps/backend/app/routers/paddocks.py
+++ b/apps/backend/app/routers/paddocks.py
@@ -3,16 +3,80 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import AuthContext, get_current_auth
 from ..db import get_db_session
-from ..schemas import PaddockResponse, PaddockUpdate
-from ..services.ownership import ensure_paddock
-from ..services.serializers import serialize_paddock
+from ..models import Paddock
+from ..schemas import PaddockCreatePayload, PaddockGpsUpdatePayload, PaddockPublic, PaddockResponse, PaddockUpdate
+from ..services.ownership import ensure_farm, ensure_paddock
+from ..services.serializers import serialize_paddock, serialize_paddock_public
 
 router = APIRouter(prefix="/api/paddocks", tags=["paddocks"])
+
+
+@router.get("", response_model=list[PaddockPublic])
+async def list_paddocks(
+    owner_id: uuid.UUID | None = Query(default=None),
+    farm_id: uuid.UUID | None = Query(default=None),
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[PaddockPublic]:
+    target_owner_id = owner_id or auth.owner_id
+    if target_owner_id != auth.owner_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not allowed to view paddocks for another owner")
+    query = select(Paddock).where(Paddock.owner_id == target_owner_id)
+    if farm_id is not None:
+        query = query.where(Paddock.farm_id == farm_id)
+    query = query.order_by(Paddock.created_at.desc())
+    result = await session.execute(query)
+    paddocks = result.scalars().all()
+    return [serialize_paddock_public(paddock) for paddock in paddocks]
+
+
+@router.post("", response_model=PaddockPublic, status_code=status.HTTP_201_CREATED)
+async def create_paddock_root(
+    payload: PaddockCreatePayload,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_db_session),
+) -> PaddockPublic:
+    owner_id = payload.ownerId or auth.owner_id
+    if owner_id != auth.owner_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cannot create paddock for another owner")
+    name = payload.name.strip()
+    if not name:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="name is required")
+    await ensure_farm(session, payload.farmId, owner_id)
+    paddock = Paddock(
+        owner_id=owner_id,
+        farm_id=payload.farmId,
+        name=name,
+        area_hectares=payload.areaHectares,
+        created_at=datetime.now(timezone.utc),
+    )
+    session.add(paddock)
+    await session.commit()
+    await session.refresh(paddock)
+    return serialize_paddock_public(paddock)
+
+
+@router.post("/{paddock_id}/gps", response_model=PaddockPublic)
+async def update_paddock_gps(
+    paddock_id: uuid.UUID,
+    payload: PaddockGpsUpdatePayload,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_db_session),
+) -> PaddockPublic:
+    paddock = await ensure_paddock(session, paddock_id, auth.owner_id)
+    paddock.gps_latitude = payload.latitude
+    paddock.gps_longitude = payload.longitude
+    paddock.gps_accuracy_m = payload.accuracy
+    paddock.gps_updated_at = datetime.now(timezone.utc)
+    await session.commit()
+    await session.refresh(paddock)
+    return serialize_paddock_public(paddock)
 
 
 @router.patch("/{paddock_id}", response_model=PaddockResponse)

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -7,6 +7,25 @@ from typing import Optional
 from pydantic import BaseModel, ConfigDict, Field
 
 
+def to_camel(string: str) -> str:
+    parts = string.split("_")
+    return parts[0] + "".join(word.capitalize() for word in parts[1:]) if parts else string
+
+
+class CamelModel(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True, alias_generator=to_camel)
+
+
+class OwnerCreatePayload(BaseModel):
+    name: str = Field(..., min_length=1)
+
+
+class OwnerPublic(CamelModel):
+    id: uuid.UUID
+    name: str
+    created_at: datetime
+
+
 class FarmCreate(BaseModel):
     name: str = Field(..., min_length=1)
     notes: str | None = None
@@ -16,6 +35,20 @@ class FarmResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID
+    name: str
+    notes: str | None
+    created_at: datetime
+
+
+class FarmCreatePayload(BaseModel):
+    ownerId: uuid.UUID | None = None
+    name: str = Field(..., min_length=1)
+    notes: str | None = None
+
+
+class FarmPublic(CamelModel):
+    id: uuid.UUID
+    owner_id: uuid.UUID
     name: str
     notes: str | None
     created_at: datetime
@@ -46,6 +79,37 @@ class PaddockResponse(BaseModel):
     gps_accuracy_m: float | None
     gps_updated_at: datetime | None
     created_at: datetime
+
+
+class PaddockCreatePayload(BaseModel):
+    ownerId: uuid.UUID | None = None
+    farmId: uuid.UUID
+    name: str = Field(..., min_length=1)
+    areaHectares: float | None = Field(default=None, ge=0)
+
+
+class PaddockGpsUpdatePayload(BaseModel):
+    latitude: float
+    longitude: float
+    accuracy: float | None = Field(default=None, ge=0)
+
+
+class GPSPoint(BaseModel):
+    latitude: float
+    longitude: float
+    accuracy: float | None = None
+
+
+class PaddockPublic(CamelModel):
+    id: uuid.UUID
+    owner_id: uuid.UUID
+    farm_id: uuid.UUID
+    name: str
+    area_hectares: float | None
+    gps_point: GPSPoint | None = None
+    gps_accuracy_m: float | None = None
+    gps_captured_at: datetime | None = None
+    created_at: datetime | None = None
 
 
 class ApplicationPaddockPayload(BaseModel):

--- a/apps/backend/app/services/serializers.py
+++ b/apps/backend/app/services/serializers.py
@@ -2,8 +2,16 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from ..models import Application, ApplicationPaddock, Paddock
-from ..schemas import ApplicationPaddockResponse, ApplicationResponse, PaddockResponse
+from ..models import Application, ApplicationPaddock, Farm, Owner, Paddock
+from ..schemas import (
+    ApplicationPaddockResponse,
+    ApplicationResponse,
+    FarmPublic,
+    GPSPoint,
+    OwnerPublic,
+    PaddockPublic,
+    PaddockResponse,
+)
 from ..utils import to_float
 
 
@@ -17,6 +25,40 @@ def serialize_paddock(paddock: Paddock) -> PaddockResponse:
         gps_longitude=to_float(paddock.gps_longitude),
         gps_accuracy_m=to_float(paddock.gps_accuracy_m),
         gps_updated_at=paddock.gps_updated_at,
+        created_at=paddock.created_at,
+    )
+
+
+def serialize_owner(owner: Owner) -> OwnerPublic:
+    return OwnerPublic(id=owner.id, name=owner.name, created_at=owner.created_at)
+
+
+def serialize_farm(farm: Farm) -> FarmPublic:
+    return FarmPublic(
+        id=farm.id,
+        owner_id=farm.owner_id,
+        name=farm.name,
+        notes=farm.notes,
+        created_at=farm.created_at,
+    )
+
+
+def serialize_paddock_public(paddock: Paddock) -> PaddockPublic:
+    latitude = to_float(paddock.gps_latitude)
+    longitude = to_float(paddock.gps_longitude)
+    accuracy = to_float(paddock.gps_accuracy_m)
+    gps_point = None
+    if latitude is not None and longitude is not None:
+        gps_point = GPSPoint(latitude=latitude, longitude=longitude, accuracy=accuracy)
+    return PaddockPublic(
+        id=paddock.id,
+        owner_id=paddock.owner_id,
+        farm_id=paddock.farm_id,
+        name=paddock.name,
+        area_hectares=to_float(paddock.area_hectares),
+        gps_point=gps_point,
+        gps_accuracy_m=accuracy,
+        gps_captured_at=paddock.gps_updated_at,
         created_at=paddock.created_at,
     )
 


### PR DESCRIPTION
## Summary
- add camelCase API schemas and serializers for owners, farms, and paddocks
- expose /api/owners, /api/farms, and /api/paddocks endpoints plus GPS updates that satisfy the dashboard contract
- scope mutations to the authenticated owner and link new owner records to the current profile

## Testing
- python -m compileall apps/backend/app
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d32d976ca88324a2bfef7044160ae8