### PR TITLE
Add mix models and endpoints for mix builder

### DIFF
--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .config import get_settings
-from .routers import applications, farms, owners, paddocks, records, weather
+from .routers import applications, farms, mixes, owners, paddocks, records, weather
 
 
 @asynccontextmanager
@@ -35,6 +35,7 @@ async def health() -> dict[str, bool]:
 
 app.include_router(owners.router)
 app.include_router(farms.router)
+app.include_router(mixes.router)
 app.include_router(paddocks.router)
 app.include_router(applications.router)
 app.include_router(records.router)

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -25,6 +25,7 @@ class Owner(Base):
     farms: Mapped[list["Farm"]] = relationship(back_populates="owner", cascade="all, delete-orphan")
     paddocks: Mapped[list["Paddock"]] = relationship(back_populates="owner", cascade="all, delete-orphan")
     applications: Mapped[list["Application"]] = relationship(back_populates="owner", cascade="all, delete-orphan")
+    mixes: Mapped[list["Mix"]] = relationship(back_populates="owner", cascade="all, delete-orphan")
 
 
 class Profile(Base):
@@ -137,6 +138,37 @@ class ApplicationPaddock(Base):
 
     application: Mapped[Application] = relationship(back_populates="paddocks")
     paddock: Mapped[Paddock] = relationship(back_populates="application_links")
+
+
+class Mix(Base):
+    __tablename__ = "mixes"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    owner_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("owners.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    total_water_l: Mapped[float] = mapped_column(Numeric, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    owner: Mapped[Owner] = relationship(back_populates="mixes")
+    items: Mapped[list["MixItem"]] = relationship(back_populates="mix", cascade="all, delete-orphan")
+
+
+class MixItem(Base):
+    __tablename__ = "mix_items"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    mix_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("mixes.id", ondelete="CASCADE"), nullable=False
+    )
+    chemical: Mapped[str] = mapped_column(String, nullable=False)
+    rate_l_per_ha: Mapped[float] = mapped_column(Numeric, nullable=False)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    mix: Mapped[Mix] = relationship(back_populates="items")
 
 
 class BlynkStation(Base):

--- a/apps/backend/app/routers/__init__.py
+++ b/apps/backend/app/routers/__init__.py
@@ -1,8 +1,9 @@
-from . import applications, farms, owners, paddocks, records, weather
+from . import applications, farms, mixes, owners, paddocks, records, weather
 
 __all__ = [
     "applications",
     "farms",
+    "mixes",
     "owners",
     "paddocks",
     "records",

--- a/apps/backend/app/routers/mixes.py
+++ b/apps/backend/app/routers/mixes.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from ..auth import AuthContext, get_current_auth
+from ..db import get_db_session
+from ..models import Mix, MixItem
+from ..schemas import MixCreate, MixResponse
+from ..services.serializers import serialize_mix
+
+router = APIRouter(prefix="/api/mixes", tags=["mixes"])
+
+
+@router.get("", response_model=list[MixResponse])
+async def list_mixes(
+    owner_id: uuid.UUID | None = Query(default=None, alias="owner_id"),
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[MixResponse]:
+    if owner_id is not None and owner_id != auth.owner_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot access mixes for another owner",
+        )
+
+    target_owner_id = owner_id or auth.owner_id
+    query = (
+        select(Mix)
+        .where(Mix.owner_id == target_owner_id)
+        .options(selectinload(Mix.items))
+        .order_by(Mix.created_at.desc())
+    )
+    result = await session.execute(query)
+    mixes = result.scalars().unique().all()
+    return [serialize_mix(mix) for mix in mixes]
+
+
+@router.post("", response_model=MixResponse, status_code=status.HTTP_201_CREATED)
+async def create_mix(
+    payload: MixCreate,
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_db_session),
+) -> MixResponse:
+    if payload.owner_id != auth.owner_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot create mix for another owner",
+        )
+
+    mix = Mix(owner_id=auth.owner_id, name=payload.name, total_water_l=payload.total_water_l)
+    session.add(mix)
+    await session.flush()
+
+    for item_payload in payload.items:
+        item = MixItem(
+            mix_id=mix.id,
+            chemical=item_payload.chemical,
+            rate_l_per_ha=item_payload.rate_l_per_ha,
+            notes=item_payload.notes,
+        )
+        session.add(item)
+
+    await session.commit()
+
+    query = (
+        select(Mix)
+        .where(Mix.id == mix.id, Mix.owner_id == auth.owner_id)
+        .options(selectinload(Mix.items))
+    )
+    result = await session.execute(query)
+    created_mix = result.scalar_one()
+    return serialize_mix(created_mix)

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -21,6 +21,43 @@ class FarmResponse(BaseModel):
     created_at: datetime
 
 
+class MixItemCreate(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    chemical: str = Field(..., min_length=1)
+    rate_l_per_ha: float = Field(..., alias="rateLPerHa", ge=0)
+    notes: str | None = None
+
+
+class MixCreate(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    owner_id: uuid.UUID = Field(alias="ownerId")
+    name: str = Field(..., min_length=1)
+    total_water_l: float = Field(..., alias="totalWaterL", ge=0)
+    items: list[MixItemCreate]
+
+
+class MixItemResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: uuid.UUID
+    chemical: str
+    rate_l_per_ha: float = Field(alias="rateLPerHa")
+    notes: str | None
+
+
+class MixResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: uuid.UUID
+    owner_id: uuid.UUID = Field(alias="ownerId")
+    name: str
+    total_water_l: float = Field(alias="totalWaterL")
+    items: list[MixItemResponse]
+    created_at: datetime = Field(alias="createdAt")
+
+
 class PaddockCreate(BaseModel):
     name: str = Field(..., min_length=1)
     area_hectares: float | None = Field(default=None, ge=0)

--- a/apps/backend/app/services/serializers.py
+++ b/apps/backend/app/services/serializers.py
@@ -2,8 +2,14 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from ..models import Application, ApplicationPaddock, Paddock
-from ..schemas import ApplicationPaddockResponse, ApplicationResponse, PaddockResponse
+from ..models import Application, ApplicationPaddock, Mix, Paddock
+from ..schemas import (
+    ApplicationPaddockResponse,
+    ApplicationResponse,
+    MixItemResponse,
+    MixResponse,
+    PaddockResponse,
+)
 from ..utils import to_float
 
 
@@ -48,4 +54,27 @@ def serialize_application(application: Application) -> ApplicationResponse:
             )
             for link in paddocks
         ],
+    )
+
+
+def serialize_mix(mix: Mix) -> MixResponse:
+    total_water = to_float(mix.total_water_l)
+    items: list[MixItemResponse] = []
+    for item in mix.items:
+        rate = to_float(item.rate_l_per_ha)
+        items.append(
+            MixItemResponse(
+                id=item.id,
+                chemical=item.chemical,
+                rate_l_per_ha=rate if rate is not None else 0.0,
+                notes=item.notes,
+            )
+        )
+    return MixResponse(
+        id=mix.id,
+        owner_id=mix.owner_id,
+        name=mix.name,
+        total_water_l=total_water if total_water is not None else 0.0,
+        created_at=mix.created_at,
+        items=items,
     )


### PR DESCRIPTION
## Summary
- add Mix and MixItem SQLAlchemy models tied to owners
- expose mix schemas/serializers using camelCase payloads
- serve mix list/create endpoints and register the router

## Testing
- python -m compileall apps/backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d32d9493d88324a029706e65865ac5