### PR TITLE
Implement application summaries and dashboard payload support

### DIFF
--- a/apps/backend/app/routers/applications.py
+++ b/apps/backend/app/routers/applications.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import Response
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,8 +13,8 @@ from ..auth import AuthContext, get_current_auth
 from ..db import get_db_session
 from ..models import Application, ApplicationPaddock
 from ..pdf import generate_application_pdf
-from ..schemas import ApplicationCreate, ApplicationResponse
-from ..services.serializers import serialize_application
+from ..schemas import ApplicationCreate, ApplicationSummary
+from ..services.serializers import serialize_application_summary
 from ..services.ownership import ensure_application, ensure_paddock
 
 router = APIRouter(prefix="/api/applications", tags=["applications"])
@@ -36,20 +36,42 @@ async def _load_application(session: AsyncSession, application_id: uuid.UUID, ow
     return application
 
 
-@router.post("", response_model=ApplicationResponse, status_code=status.HTTP_201_CREATED)
+@router.get("", response_model=list[ApplicationSummary])
+async def list_applications(
+    owner_id: uuid.UUID | None = Query(default=None),
+    auth: AuthContext = Depends(get_current_auth),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[ApplicationSummary]:
+    if owner_id is not None and owner_id != auth.owner_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cannot access applications for another owner")
+
+    target_owner_id = owner_id or auth.owner_id
+
+    query = (
+        select(Application)
+        .where(Application.owner_id == target_owner_id)
+        .options(selectinload(Application.paddocks))
+        .order_by(Application.started_at.desc())
+    )
+    result = await session.execute(query)
+    applications = result.scalars().all()
+    return [serialize_application_summary(application) for application in applications]
+
+
+@router.post("", response_model=ApplicationSummary, status_code=status.HTTP_201_CREATED)
 async def start_application(
     payload: ApplicationCreate,
     auth: AuthContext = Depends(get_current_auth),
     session: AsyncSession = Depends(get_db_session),
-) -> ApplicationResponse:
-    if not payload.paddocks:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="At least one paddock is required")
+) -> ApplicationSummary:
+    if payload.owner_id != auth.owner_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cannot create application for another owner")
 
-    started_at = payload.started_at or datetime.now(timezone.utc)
+    started_at = payload.started_at
     application = Application(
         owner_id=auth.owner_id,
         mix_id=payload.mix_id,
-        operator_user_id=payload.operator_user_id or auth.user_id,
+        operator_user_id=auth.user_id,
         started_at=started_at,
         notes=payload.notes,
         water_source=payload.water_source,
@@ -58,36 +80,28 @@ async def start_application(
     session.add(application)
     await session.flush()
 
-    for paddock_payload in payload.paddocks:
-        paddock = await ensure_paddock(session, paddock_payload.paddock_id, auth.owner_id)
-        gps_captured_at = None
-        if paddock_payload.gps_lat is not None and paddock_payload.gps_lng is not None:
-            gps_captured_at = datetime.now(timezone.utc)
+    for paddock_id in payload.paddock_ids:
+        await ensure_paddock(session, paddock_id, auth.owner_id)
         link = ApplicationPaddock(
             owner_id=auth.owner_id,
             application_id=application.id,
-            paddock_id=paddock.id,
-            gps_latitude=paddock_payload.gps_lat,
-            gps_longitude=paddock_payload.gps_lng,
-            gps_accuracy_m=paddock_payload.gps_accuracy_m,
-            gps_captured_at=gps_captured_at,
+            paddock_id=paddock_id,
         )
         session.add(link)
     await session.commit()
-    await session.refresh(application)
     application = await _load_application(session, application.id, auth.owner_id)
-    return serialize_application(application)
+    return serialize_application_summary(application)
 
 
-@router.post("/{application_id}/finalize", response_model=ApplicationResponse)
+@router.post("/{application_id}/finalize", response_model=ApplicationSummary)
 async def finalize_application(
     application_id: uuid.UUID,
     auth: AuthContext = Depends(get_current_auth),
     session: AsyncSession = Depends(get_db_session),
-) -> ApplicationResponse:
+) -> ApplicationSummary:
     application = await ensure_application(session, application_id, auth.owner_id)
     if application.finalized:
-        return serialize_application(await _load_application(session, application_id, auth.owner_id))
+        return serialize_application_summary(await _load_application(session, application_id, auth.owner_id))
 
     finished_at = datetime.now(timezone.utc)
     await session.execute(
@@ -97,7 +111,7 @@ async def finalize_application(
     )
     await session.commit()
     application = await _load_application(session, application_id, auth.owner_id)
-    return serialize_application(application)
+    return serialize_application_summary(application)
 
 
 @router.get("/{application_id}/export.pdf", response_class=Response)

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -48,20 +48,16 @@ class PaddockResponse(BaseModel):
     created_at: datetime
 
 
-class ApplicationPaddockPayload(BaseModel):
-    paddock_id: uuid.UUID
-    gps_lat: float | None = None
-    gps_lng: float | None = None
-    gps_accuracy_m: float | None = Field(default=None, ge=0)
-
-
 class ApplicationCreate(BaseModel):
-    paddocks: list[ApplicationPaddockPayload]
-    mix_id: uuid.UUID | None = None
-    started_at: datetime | None = None
-    operator_user_id: uuid.UUID | None = None
+    model_config = ConfigDict(populate_by_name=True)
+
+    owner_id: uuid.UUID = Field(alias="ownerId")
+    mix_id: uuid.UUID = Field(alias="mixId")
+    paddock_ids: list[uuid.UUID] = Field(alias="paddockIds", min_length=1)
+    started_at: datetime = Field(alias="startedAt")
+    operator_name: str | None = Field(default=None, alias="operatorName")
     notes: str | None = None
-    water_source: str | None = None
+    water_source: str | None = Field(default=None, alias="waterSource")
 
 
 class ApplicationPaddockResponse(BaseModel):
@@ -92,6 +88,28 @@ class ApplicationResponse(BaseModel):
     humidity_pct: float | None
     created_at: datetime
     paddocks: list[ApplicationPaddockResponse]
+
+
+class WeatherSummary(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    wind_speed_ms: float | None = Field(default=None, serialization_alias="windSpeedMs")
+    wind_direction_deg: float | None = Field(default=None, serialization_alias="windDirectionDeg")
+    temp_c: float | None = Field(default=None, serialization_alias="temperatureC")
+    humidity_pct: float | None = Field(default=None, serialization_alias="humidityPct")
+
+
+class ApplicationSummary(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: uuid.UUID
+    owner_id: uuid.UUID = Field(serialization_alias="ownerId")
+    mix_id: uuid.UUID | None = Field(default=None, serialization_alias="mixId")
+    paddock_ids: list[uuid.UUID] = Field(serialization_alias="paddockIds")
+    started_at: datetime = Field(serialization_alias="startedAt")
+    finished_at: datetime | None = Field(default=None, serialization_alias="finishedAt")
+    finalized: bool
+    weather: WeatherSummary | None = Field(default=None, serialization_alias="weather")
 
 
 class WeatherSnapshot(BaseModel):

--- a/apps/backend/app/services/serializers.py
+++ b/apps/backend/app/services/serializers.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from typing import Iterable
 
 from ..models import Application, ApplicationPaddock, Paddock
-from ..schemas import ApplicationPaddockResponse, ApplicationResponse, PaddockResponse
+from ..schemas import (
+    ApplicationPaddockResponse,
+    ApplicationResponse,
+    ApplicationSummary,
+    PaddockResponse,
+    WeatherSummary,
+)
 from ..utils import to_float
 
 
@@ -48,4 +54,30 @@ def serialize_application(application: Application) -> ApplicationResponse:
             )
             for link in paddocks
         ],
+    )
+
+
+def serialize_application_summary(application: Application) -> ApplicationSummary:
+    paddock_ids = [link.paddock_id for link in application.paddocks]
+    wind_speed = to_float(application.wind_speed_ms)
+    wind_direction = to_float(application.wind_direction_deg)
+    temperature = to_float(application.temp_c)
+    humidity = to_float(application.humidity_pct)
+    weather: WeatherSummary | None = None
+    if any(value is not None for value in (wind_speed, wind_direction, temperature, humidity)):
+        weather = WeatherSummary(
+            wind_speed_ms=wind_speed,
+            wind_direction_deg=wind_direction,
+            temp_c=temperature,
+            humidity_pct=humidity,
+        )
+    return ApplicationSummary(
+        id=application.id,
+        owner_id=application.owner_id,
+        mix_id=application.mix_id,
+        paddock_ids=paddock_ids,
+        started_at=application.started_at,
+        finished_at=application.finished_at,
+        finalized=application.finalized,
+        weather=weather,
     )


### PR DESCRIPTION
## Summary
- add an /api/applications GET endpoint that returns application summaries with camelCase keys
- update application creation to accept dashboard payload fields and build paddock links server-side
- reuse the same summary serializer across create and finalize responses for consistent camelCase output

## Testing
- python -m compileall apps/backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d32d9ed7ec8324ba4905abbf063c69