### PR TITLE
Add summary serializers for applications

### DIFF
--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -131,6 +131,28 @@ class ApplicationResponse(BaseModel):
     paddocks: list[ApplicationPaddockResponse]
 
 
+class WeatherSummary(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    wind_speed_ms: float | None = Field(default=None, alias="windSpeedMs")
+    wind_direction_deg: float | None = Field(default=None, alias="windDirectionDeg")
+    temp_c: float | None = Field(default=None, alias="temperatureC")
+    humidity_pct: float | None = Field(default=None, alias="humidityPct")
+
+
+class ApplicationSummary(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: uuid.UUID
+    owner_id: uuid.UUID = Field(alias="ownerId")
+    mix_id: uuid.UUID | None = Field(default=None, alias="mixId")
+    paddock_ids: list[uuid.UUID] = Field(alias="paddockIds")
+    started_at: datetime = Field(alias="startedAt")
+    finished_at: datetime | None = Field(default=None, alias="finishedAt")
+    finalized: bool
+    weather: WeatherSummary | None = None
+
+
 class WeatherSnapshot(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 

--- a/apps/backend/app/services/serializers.py
+++ b/apps/backend/app/services/serializers.py
@@ -6,9 +6,11 @@ from ..models import Application, ApplicationPaddock, Mix, Paddock
 from ..schemas import (
     ApplicationPaddockResponse,
     ApplicationResponse,
+    ApplicationSummary,
     MixItemResponse,
     MixResponse,
     PaddockResponse,
+    WeatherSummary,
 )
 from ..utils import to_float
 
@@ -54,6 +56,32 @@ def serialize_application(application: Application) -> ApplicationResponse:
             )
             for link in paddocks
         ],
+    )
+
+
+def serialize_application_summary(application: Application) -> ApplicationSummary:
+    paddock_ids = [link.paddock_id for link in application.paddocks]
+    wind_speed = to_float(application.wind_speed_ms)
+    wind_direction = to_float(application.wind_direction_deg)
+    temperature = to_float(application.temp_c)
+    humidity = to_float(application.humidity_pct)
+    weather: WeatherSummary | None = None
+    if any(value is not None for value in (wind_speed, wind_direction, temperature, humidity)):
+        weather = WeatherSummary(
+            wind_speed_ms=wind_speed,
+            wind_direction_deg=wind_direction,
+            temp_c=temperature,
+            humidity_pct=humidity,
+        )
+    return ApplicationSummary(
+        id=application.id,
+        owner_id=application.owner_id,
+        mix_id=application.mix_id,
+        paddock_ids=paddock_ids,
+        started_at=application.started_at,
+        finished_at=application.finished_at,
+        finalized=application.finalized,
+        weather=weather,
     )
 
 


### PR DESCRIPTION
## Summary
- add WeatherSummary and ApplicationSummary Pydantic models with camelCase aliases for API payloads
- extend serializers to expose application summaries alongside existing mix serialization

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d34f8797ac83248583f4816d615380