### PR TITLE
Align application payload schema aliases with frontend expectation

### DIFF
--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -86,19 +86,26 @@ class PaddockResponse(BaseModel):
 
 
 class ApplicationPaddockPayload(BaseModel):
-    paddock_id: uuid.UUID
-    gps_lat: float | None = None
-    gps_lng: float | None = None
-    gps_accuracy_m: float | None = Field(default=None, ge=0)
+    model_config = ConfigDict(populate_by_name=True)
+
+    paddock_id: uuid.UUID = Field(alias="paddockId")
+    gps_lat: float | None = Field(default=None, alias="gpsLat")
+    gps_lng: float | None = Field(default=None, alias="gpsLng")
+    gps_accuracy_m: float | None = Field(default=None, ge=0, alias="gpsAccuracyM")
 
 
 class ApplicationCreate(BaseModel):
-    paddocks: list[ApplicationPaddockPayload]
-    mix_id: uuid.UUID | None = None
-    started_at: datetime | None = None
-    operator_user_id: uuid.UUID | None = None
+    model_config = ConfigDict(populate_by_name=True)
+
+    owner_id: uuid.UUID | None = Field(default=None, alias="ownerId")
+    mix_id: uuid.UUID | None = Field(default=None, alias="mixId")
+    paddock_ids: list[uuid.UUID] | None = Field(default=None, alias="paddockIds")
+    paddocks: list[ApplicationPaddockPayload] | None = None
+    started_at: datetime | None = Field(default=None, alias="startedAt")
+    operator_user_id: uuid.UUID | None = Field(default=None, alias="operatorUserId")
+    operator_name: str | None = Field(default=None, alias="operatorName")
     notes: str | None = None
-    water_source: str | None = None
+    water_source: str | None = Field(default=None, alias="waterSource")
 
 
 class ApplicationPaddockResponse(BaseModel):


### PR DESCRIPTION
## Summary
- add camelCase aliases to the application creation payload models
- allow the applications router to build paddock payloads from paddockIds when no detailed payloads are supplied

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3529f6d3c83249683f2ecdaf14ca1