### PR TITLE
Resolve Dockerfile merge conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.12-slim
 
+# System deps for WeasyPrint
 RUN apt-get update && apt-get install -y \
     build-essential \
     libpango-1.0-0 \


### PR DESCRIPTION
## Summary
- restore the Dockerfile after merge conflict by keeping the WeasyPrint dependency comment and shared configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d364a4ac1483248ea55d3fb6d9c49f