### PR TITLE
Fix backend imports and configuration for Render deployment

### DIFF
--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -1,28 +1,26 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import List
 
-from pydantic import AnyHttpUrl, BaseSettings, Field, validator
+from pydantic import AnyHttpUrl, Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Application configuration loaded from environment variables."""
 
-    database_url: str = Field(..., env="DATABASE_URL")
-    allowed_origins: List[str] = Field(default_factory=list, env="ALLOWED_ORIGINS")
-    supabase_jwks_url: AnyHttpUrl = Field(..., env="SUPABASE_JWKS_URL")
-    supabase_expected_aud: str = Field("authenticated", env="SUPABASE_EXPECTED_AUD")
-    public_record_base_url: AnyHttpUrl = Field(..., env="PUBLIC_RECORD_BASE_URL")
-    environment: str = Field("development", env="FASTAPI_ENV")
-    jwks_cache_ttl_seconds: int = Field(3600, env="JWKS_CACHE_TTL_SECONDS")
+    model_config = SettingsConfigDict(env_file=".env", case_sensitive=False)
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = False
+    database_url: str
+    allowed_origins: list[str] = Field(default_factory=list)
+    supabase_jwks_url: AnyHttpUrl
+    supabase_expected_aud: str = "authenticated"
+    public_record_base_url: AnyHttpUrl
+    environment: str = "development"
+    jwks_cache_ttl_seconds: int = 3600
 
-    @validator("allowed_origins", pre=True)
-    def _split_origins(cls, value: List[str] | str | None) -> List[str]:
+    @field_validator("allowed_origins", mode="before")
+    def _split_origins(cls, value: list[str] | str | None) -> list[str]:
         if not value:
             return []
         if isinstance(value, list):

--- a/apps/backend/app/routers/records.py
+++ b/apps/backend/app/routers/records.py
@@ -1,33 +1,41 @@
-# apps/backend/routes/records.py
-from fastapi import APIRouter, HTTPException, Request
-from fastapi.templating import Jinja2Templates
+from __future__ import annotations
+
 from datetime import datetime, timezone
+from typing import Any, Mapping
 from pathlib import Path
 
-from apps.backend.db_supabase import (
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.templating import Jinja2Templates
+
+from ..db_supabase import (
     get_app_by_id, get_owner_by_id, get_paddock_by_id
 )
 
 router = APIRouter()
 
-# Point to: apps/backend/app/templates/application/
-# (Adjust the pieces below if your folder name is different)
-TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "app" / "templates" / "application"
-templates = Jinja2Templates(directory=str(TEMPLATES_DIR))  # <-- this is the correct way
+# Templates live in ``apps/backend/app/templates``.
+TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "templates"
+TEMPLATE_NAME = "application.html"
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
-def kph_to_ms(v):
-    return None if v is None else float(v) * (1000.0/3600.0)
 
-def paddock_to_template(p):
-    if not p:
+def kph_to_ms(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value) * (1000.0 / 3600.0)
+
+
+def paddock_to_template(paddock: Mapping[str, Any] | None) -> Mapping[str, Any] | None:
+    if not paddock:
         return None
     return {
-        "name": p.get("paddock_name"),
-        "gps_latitude": p.get("centroid_lat"),
-        "gps_longitude": p.get("centroid_lng"),
-        "gps_accuracy_m": "-",               # not stored in your schema
-        "gps_captured_at": p.get("created_at"),
+        "name": paddock.get("paddock_name"),
+        "gps_latitude": paddock.get("centroid_lat"),
+        "gps_longitude": paddock.get("centroid_lng"),
+        "gps_accuracy_m": "-",  # not stored in the schema
+        "gps_captured_at": paddock.get("created_at"),
     }
+
 
 @router.get("/applications/{application_id}/preview")
 async def preview_application(request: Request, application_id: str):
@@ -35,14 +43,14 @@ async def preview_application(request: Request, application_id: str):
     if not app_row:
         raise HTTPException(404, "Application not found")
 
-    owner   = await get_owner_by_id(app_row["owner_id"]) if app_row.get("owner_id") else None
+    owner = await get_owner_by_id(app_row["owner_id"]) if app_row.get("owner_id") else None
     paddock = await get_paddock_by_id(app_row["paddock_id"]) if app_row.get("paddock_id") else None
 
     weather = {
-        "wind_speed_ms":      kph_to_ms(app_row.get("weather_wind_kph")),
+        "wind_speed_ms": kph_to_ms(app_row.get("weather_wind_kph")),
         "wind_direction_deg": app_row.get("weather_wind_dir"),
-        "temp_c":             app_row.get("weather_temp_c"),
-        "humidity_pct":       app_row.get("weather_rh_pct"),
+        "temp_c": app_row.get("weather_temp_c"),
+        "humidity_pct": app_row.get("weather_rh_pct"),
     }
 
     context = {
@@ -60,19 +68,38 @@ async def preview_application(request: Request, application_id: str):
         "record_url": app_row.get("pdf_url"),
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
     }
-    # Make sure the file inside that folder is actually named "templates.html"
-    return templates.TemplateResponse("templates.html", context)
-    @router.get("/test-template")
+
+    return templates.TemplateResponse(TEMPLATE_NAME, context)
+
+
+@router.get("/test-template")
 def test_template(request: Request):
     ctx = {
         "request": request,
         "owner": {"name": "My Farm Pty Ltd"},
-        "application": {"id": "TEST", "started_at": "now", "finalized": True, "notes": "hello"},
-        "paddocks": [{"name":"North Back","gps_latitude":-36.12,"gps_longitude":144.75,"gps_accuracy_m":"-","gps_captured_at":"now"}],
-        "weather": {"wind_speed_ms": 12.5*(1000/3600), "wind_direction_deg":240, "temp_c":20.4, "humidity_pct":58},
+        "application": {
+            "id": "TEST",
+            "started_at": "now",
+            "finalized": True,
+            "notes": "hello",
+        },
+        "paddocks": [
+            {
+                "name": "North Back",
+                "gps_latitude": -36.12,
+                "gps_longitude": 144.75,
+                "gps_accuracy_m": "-",
+                "gps_captured_at": "now",
+            }
+        ],
+        "weather": {
+            "wind_speed_ms": 12.5 * (1000 / 3600),
+            "wind_direction_deg": 240,
+            "temp_c": 20.4,
+            "humidity_pct": 58,
+        },
         "qr_code": None,
         "record_url": None,
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
     }
-    return templates.TemplateResponse("templates.html", ctx)
-
+    return templates.TemplateResponse(TEMPLATE_NAME, ctx)

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -1,12 +1,12 @@
-# apps/backend/main.py
-import os
-from fastapi import FastAPI
-from apps.backend.routes.records import router as records_router
+"""Compatibility wrapper for the FastAPI application.
 
-app = FastAPI(title="Infield Spray Record Backend")
-app.include_router(records_router)
+Render deployments historically imported ``apps.backend.main:app``.
+This module now simply re-exports the actual application defined in
+``apps.backend.app.main`` so the legacy import path continues to work.
+"""
 
-# Optional: health check
-@app.get("/healthz")
-def healthz():
-    return {"ok": True}
+from apps.backend.app.main import app as _app
+
+__all__ = ["app"]
+
+app = _app


### PR DESCRIPTION
## Summary
- expose the FastAPI application via apps.backend.main so existing Render start commands work
- migrate backend settings to pydantic-settings / Pydantic v2 APIs
- correct the records router imports and template wiring

## Testing
- python -m compileall apps/backend

------
https://chatgpt.com/codex/tasks/task_e_68d36b3212208324bafc3b224d7dccae