### PR TITLE
Restore compatibility for legacy router imports

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,0 +1,16 @@
+"""Top-level compatibility package for the project codebase.
+
+Historically the backend application and its routers were imported from the
+``apps`` namespace (for example ``apps.backend.main``).  The package became a
+namespace package after the refactor, which caused import resolution issues in
+some deployment environments.  Providing an explicit module ensures a standard
+package object is available and allows us to re-export the backend helpers
+needed by legacy imports.
+"""
+
+from importlib import import_module as _import_module
+
+# Re-export the backend package so ``import apps.backend`` continues to work.
+backend = _import_module("apps.backend")
+
+__all__ = ["backend"]

--- a/apps/backend/__init__.py
+++ b/apps/backend/__init__.py
@@ -1,0 +1,15 @@
+"""Compatibility package for legacy backend imports.
+
+Legacy deployment scripts historically referenced modules such as
+``apps.backend.main`` and ``apps.backend.routes``.  The backend code now lives
+primarily under :mod:`apps.backend.app`, so we re-export the relevant modules
+here to preserve the old import paths.
+"""
+
+from importlib import import_module as _import_module
+
+app = _import_module("apps.backend.app")
+main = _import_module("apps.backend.main")
+routes = _import_module("apps.backend.routes")
+
+__all__ = ["app", "main", "routes"]

--- a/apps/backend/routes/__init__.py
+++ b/apps/backend/routes/__init__.py
@@ -1,0 +1,19 @@
+"""Compatibility package for legacy router imports.
+
+Historically the FastAPI routers lived under :mod:`apps.backend.routes`.  The
+project reorganised the code so the canonical modules are now in
+``apps.backend.app.routers``.  This package re-exports the modern router
+modules so that legacy import paths continue to work without modification.
+"""
+
+from . import applications, farms, mixes, owners, paddocks, records, weather
+
+__all__ = [
+    "applications",
+    "farms",
+    "mixes",
+    "owners",
+    "paddocks",
+    "records",
+    "weather",
+]

--- a/apps/backend/routes/applications.py
+++ b/apps/backend/routes/applications.py
@@ -1,0 +1,5 @@
+"""Compatibility shim for :mod:`apps.backend.app.routers.applications`."""
+
+from ..app.routers.applications import router
+
+__all__ = ["router"]

--- a/apps/backend/routes/farms.py
+++ b/apps/backend/routes/farms.py
@@ -1,0 +1,5 @@
+"""Compatibility shim for :mod:`apps.backend.app.routers.farms`."""
+
+from ..app.routers.farms import router
+
+__all__ = ["router"]

--- a/apps/backend/routes/mixes.py
+++ b/apps/backend/routes/mixes.py
@@ -1,0 +1,5 @@
+"""Compatibility shim for :mod:`apps.backend.app.routers.mixes`."""
+
+from ..app.routers.mixes import router
+
+__all__ = ["router"]

--- a/apps/backend/routes/owners.py
+++ b/apps/backend/routes/owners.py
@@ -1,0 +1,5 @@
+"""Compatibility shim for :mod:`apps.backend.app.routers.owners`."""
+
+from ..app.routers.owners import router
+
+__all__ = ["router"]

--- a/apps/backend/routes/paddocks.py
+++ b/apps/backend/routes/paddocks.py
@@ -1,0 +1,5 @@
+"""Compatibility shim for :mod:`apps.backend.app.routers.paddocks`."""
+
+from ..app.routers.paddocks import router
+
+__all__ = ["router"]

--- a/apps/backend/routes/records.py
+++ b/apps/backend/routes/records.py
@@ -1,0 +1,5 @@
+"""Compatibility shim for :mod:`apps.backend.app.routers.records`."""
+
+from ..app.routers.records import preview_application, router, test_template
+
+__all__ = ["router", "preview_application", "test_template"]

--- a/apps/backend/routes/weather.py
+++ b/apps/backend/routes/weather.py
@@ -1,0 +1,5 @@
+"""Compatibility shim for :mod:`apps.backend.app.routers.weather`."""
+
+from ..app.routers.weather import router
+
+__all__ = ["router"]


### PR DESCRIPTION
## Summary
- add a lightweight ``apps.backend.routes`` package that re-exports the modern router modules
- allow legacy imports such as ``apps.backend.routes.records`` to keep working after the router relocation
- provide explicit ``apps`` and ``apps.backend`` package initialisers so namespace imports resolve reliably in every environment

## Testing
- python -m compileall apps


------
https://chatgpt.com/codex/tasks/task_e_68d36dcfa1a083249424abed720dec50