### PR TITLE
Fix backend deployment dependencies and response handling

### DIFF
--- a/apps/backend/app/pdf.py
+++ b/apps/backend/app/pdf.py
@@ -13,7 +13,10 @@ from .config import get_settings
 from .models import Application, ApplicationPaddock
 from .utils import to_float
 
-_env = Environment(loader=PackageLoader("app", "templates"), autoescape=select_autoescape(["html", "xml"]))
+_env = Environment(
+    loader=PackageLoader("apps.backend.app", "templates"),
+    autoescape=select_autoescape(["html", "xml"]),
+)
 
 
 def _qr_data_uri(url: str) -> str:

--- a/apps/backend/app/routers/paddocks.py
+++ b/apps/backend/app/routers/paddocks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import AuthContext, get_current_auth
@@ -48,12 +48,17 @@ async def update_paddock(
     return serialize_paddock(paddock)
 
 
-@router.delete("/{paddock_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{paddock_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
 async def delete_paddock(
     paddock_id: uuid.UUID,
     auth: AuthContext = Depends(get_current_auth),
     session: AsyncSession = Depends(get_db_session),
-) -> None:
+) -> Response:
     paddock = await ensure_paddock(session, paddock_id, auth.owner_id)
     await session.delete(paddock)
     await session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,9 @@ python-multipart==0.0.9
 supabase==2.5.1
 httpx==0.27.0
 pydantic==2.9.2
+pydantic-settings==2.6.1
+sqlalchemy==2.0.35
+asyncpg==0.29.0
+PyJWT[crypto]==2.9.0
+qrcode==7.4.2
 weasyprint==62.3


### PR DESCRIPTION
## Summary
- include the backend ORM, auth, and utility packages in requirements so Render installs everything the FastAPI app needs
- point the PDF generator's Jinja2 package loader at the actual `apps.backend.app` package so templates resolve correctly
- return an explicit empty `Response` for the paddock delete endpoint to satisfy FastAPI's 204 response constraints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3744e03a88324ac2c09059541cdbc