### PR TITLE
Ensure backend app boots with robust health endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 ENV PORT=8000
-CMD ["uvicorn", "apps.backend.main:app", "--host", "0.0.0.0", "--port", "8000"]
+ENV PYTHONPATH=/app
+CMD ["python", "-m", "uvicorn", "apps.backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- point the Docker container entrypoint at `apps.backend.app.main:app` and expose the project directory on `PYTHONPATH`
- replace the FastAPI application module with a resilient health check that only attaches routers when imports succeed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d37a074dbc8324b5d3316754db1c6c